### PR TITLE
fix: 解决 ipad 屏幕旋转问题

### DIFF
--- a/FWSideMenu/FWSideMenuContainerViewController.swift
+++ b/FWSideMenu/FWSideMenuContainerViewController.swift
@@ -872,4 +872,9 @@ extension FWSideMenuContainerViewController {
         NotificationCenter.default.post(name: NSNotification.Name(rawValue: FWSideMenuStateNotificationEvent), object: self, userInfo: userInfo)
         
     }
+    
+    open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        centerMaskView.frame = CGRect(x: 0, y: 0, width: size.width, height: size.height)
+    }
 }


### PR DESCRIPTION
如果 ipad 在横屏启动的情况下，会出现遮罩 view frame 错误的情况。
具体复现步骤为

### 1. 横屏启动

### 2.打开侧滑栏（是否关闭侧滑栏都可以）

### 3.切换成竖屏，就会出现如图所示的情况

![image](https://user-images.githubusercontent.com/23251844/98803192-56ab1100-244f-11eb-872d-e1301cf49f1b.png)
